### PR TITLE
Update with operators as in DualNumbers.jl

### DIFF
--- a/src/hyperdual.jl
+++ b/src/hyperdual.jl
@@ -201,6 +201,10 @@ end
 abs2(z::Hyper) = z*z
 abs(z::Hyper) = sqrt(abs2(z))                    # Is this correct?
 
+for op in (:real, :imag, :conj, :float, :complex)
+    @eval Base.$op(z::Hyper) = Hyper($op(real(z)), $op(eps1(z)), $op(eps2(z)), $op(eps1eps2(z)))
+end
+
 function ^(z::Hyper, w::Rational)
   deriv = w * real(z)^(w-1)
   hyper(real(z)^w, eps1(z)*deriv, eps2(z)*deriv,


### PR DESCRIPTION
I thought it was odd that `conj` raised an error (which happens when calling, e.g., `x'x` on a hyper-dual-valued `x`. Mininal Example with error:
```julia
julia> conj(hyper(1.0))
ERROR: MethodError: no method matching conj(::Hyper{Float64})
Closest candidates are:
  conj(::Missing) at missing.jl:79
  conj(::Real) at number.jl:191
  conj(::Complex) at complex.jl:259
  ...
Stacktrace:
 [1] top-level scope at none:0
```
So I thought I'd suggest to add the operator loop that is in DualNumbers.jl (https://github.com/JuliaDiff/DualNumbers.jl/blob/27a75783e8702e2a637679f8cb8e1bf7e8b04b5a/src/dual.jl#L191)
